### PR TITLE
Clean up generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,4 @@ This work is freely available under the terms of the MIT license.
 ## Contributors
 
 * [Ryan Marcus](https://rmarcus.info)
+* [Richard Barnes](https://richard.science)


### PR DESCRIPTION
Add #pragma once header guards to C++ output - this is the primary syntactic change as it allows for safe inclusion of the generated headers in multiple files.
Clean up generated code by adding some spacing and sorting includes - makes generated code (slightly) easier to read.
Update contributors.

A side-effect of the PR is to eliminate trailing whitespace in the touched files.